### PR TITLE
Fix how command_name is passed by ClusterPipeline

### DIFF
--- a/redis/cluster.py
+++ b/redis/cluster.py
@@ -2184,7 +2184,7 @@ class ClusterPipeline(RedisCluster):
                 if node_name not in nodes:
                     redis_node = self.get_redis_connection(node)
                     try:
-                        connection = get_connection(redis_node, c.args)
+                        connection = get_connection(redis_node, *c.args)
                     except (ConnectionError, TimeoutError):
                         for n in nodes.values():
                             n.connection_pool.release(n.connection)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2998,6 +2998,21 @@ class TestClusterPipeline:
             str(ex.value).startswith("shard_hint is deprecated in cluster mode") is True
         )
 
+    def test_pipeline_get_connection_called_with_command(self, request):
+        calls = []
+        class MockConnectionPool(ConnectionPool):
+            def get_connection(self, command_name, *keys, **options) -> "Connection":
+                nonlocal calls
+                calls += [command_name]
+                return super(MockConnectionPool, self).get_connection(command_name, *keys, **options)
+
+        with _get_client(redis.Redis, request, connection_pool_class=MockConnectionPool) as r:
+            with r.pipeline() as pipe:
+                pipe.set('foo', 'bar')
+                pipe.execute()
+
+            assert calls[-1] == 'SET'
+
     def test_redis_cluster_pipeline(self, r):
         """
         Test that we can use a pipeline with the RedisCluster class


### PR DESCRIPTION
Previously, the command_name arg to ConnectionPool ended up being a tuple of the command name and args, instead of just the command name.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [ ] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
